### PR TITLE
Add cross-platform support in dockerfile for amd64, arm64, and arm v7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+# To allow for cross-platform compilation (supporting both amd64 AND arm64 from the same container)
+# the $BUILDPLATFORM variable is used here so that it can be injected during build specifyiing the desired platform(s) via:
+# docker build --platform linux/amd64,linux/arm64,linux/arm/v7 -t kalypso-kalypso-scheduler-controller-manager .
+FROM --platform=$BUILDPLATFORM golang:1.20 AS builder
+
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
To combat issues running the scheduler on ARM based chips, the $BUILDPLATFORM variable has been added which should be used like: `docker build --platform linux/amd64,linux/arm64,linux/arm/v7 -t kalypso-kalypso-scheduler-controller-manager .`